### PR TITLE
Adding config path as launch argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+v2.4.1
+    - Fix https://github.com/mikerhodes/github-to-omnifocus/issues/22
 v2.4
     - Fix https://github.com/mikerhodes/github-to-omnifocus/issues/10
 v2.3

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build run test
 
-PROJECT_VERSION=v2.4
+PROJECT_VERSION=v2.4.1
 
 run: build
 	./github2omnifocus

--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ As mentioned, the only value that must be specified is `AccessToken`.
     be unique for each type of task, and it isn't necessary to give the
     app its "own" projects as it uses tags to identify its own tasks.
 
+## Config path can be passed in
+
+This can be useful if you perhaps have multiple github instances to sync with.
+You can simply make multiple config files and pass them into the run command like this..
+
+```
+github2omnifocus --config ~/.config/github2omnifocus/enterprise-config.json
+```
+
 ## Known Issues
 
 See the [Issues](https://github.com/mikerhodes/github-to-omnifocus/issues) in

--- a/cmd/github2omnifocus/main.go
+++ b/cmd/github2omnifocus/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"log"
 	"time"
 
@@ -29,7 +30,10 @@ type GHDesiredState struct {
 func main() {
 	log.Printf("[main] Starting github2omnifocus; version: %s.", Version)
 
-	c, err := internal.LoadConfig()
+	configPathOverride := flag.String("config", "", "Path to the config file")
+	flag.Parse()
+
+	c, err := internal.LoadConfig(*configPathOverride)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/config.go
+++ b/internal/config.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -33,15 +32,20 @@ type Config struct {
 }
 
 // LoadConfig loads JSON config from ~/.config/github2omnifocus/config.json
-func LoadConfig() (Config, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return Config{}, fmt.Errorf("could not find home dir: %v", err)
+func LoadConfig(configPathOverride string) (Config, error) {
+	var configPath string
+	if configPathOverride != "" {
+		configPath = configPathOverride
+	} else {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return Config{}, fmt.Errorf("could not find home dir: %v", err)
+		}
+		configPath = path.Join(home, ".config", "github2omnifocus", "config.json")
 	}
-	configPath := path.Join(home, ".config", "github2omnifocus", "config.json")
 
 	var bytes []byte
-	bytes, err = ioutil.ReadFile(configPath)
+	bytes, err := os.ReadFile(configPath)
 	if err != nil {
 		return Config{}, fmt.Errorf("expected config.json at %s: %v", configPath, err)
 	}


### PR DESCRIPTION
For my job we run some repos in github.com - and some in an enterprise. This allows an easy way to run app with different configs.
fixes: #22 